### PR TITLE
#445: Speedup minitests tests and use multipe cores instead of one

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -28,6 +28,7 @@ require "date"
 require "rdoc"
 require "colorize"
 require "rake/clean"
+require "concurrent"
 
 # @todo #/DEV Investigate the possibility of using migrations from active_record
 #  - Rake tasks https://gist.github.com/schickling/6762581
@@ -56,6 +57,7 @@ end
 require "rake/testtask"
 desc "Run all unit tests"
 Rake::TestTask.new(:test) do |t|
+  ENV["MT_CPU"] = Concurrent.processor_count.to_s
   t.libs << "test"
   t.libs << "lib"
   t.test_files = FileList["test/**/*_test.rb"]

--- a/lib/lazylead/cli/app.rb
+++ b/lib/lazylead/cli/app.rb
@@ -70,7 +70,7 @@ module Lazylead
         ActiveRecord::Base.establish_connection(
           adapter: "sqlite3",
           database: @db,
-          pool: opts[:max_connections]
+          pool: opts[:max_connections] || ENV["MT_CPU"]
         )
         @log.debug "Database connection established"
       end

--- a/test/test.rb
+++ b/test/test.rb
@@ -51,6 +51,15 @@ module Lazylead
     include Minitest::Hooks
 
     make_my_diffs_pretty!
+    parallelize(workers: ENV["MT_CPU"].to_i)
+
+    parallelize_setup do |worker|
+      SimpleCov.command_name "#{SimpleCov.command_name}-#{worker}"
+    end
+
+    parallelize_teardown do |_worker|
+      SimpleCov.result
+    end
 
     def around
       Timeout.timeout(


### PR DESCRIPTION
```
Finished in 7.00907s
197 tests, 403 assertions, 0 failures, 0 errors, 12 skips
Coverage report generated for Unit Tests, Unit Tests-0, Unit Tests-1, Unit Tests-2, Unit Tests-3, Unit Tests-4, Unit Tests-5, Unit Tests-6, Unit Tests-7 to /Users/viktarnikifarau/Projects/VikNik599/lazylead/coverage. 1347 / 1557 LOC (86.51%) covered.
```