### PR TITLE
Remove unneeded existence check

### DIFF
--- a/lib/lazylead/postman.rb
+++ b/lib/lazylead/postman.rb
@@ -133,7 +133,7 @@ module Lazylead
     # Assemble file name where email to be print
     def filename(opts)
       dir = @env.fetch("file_postman_dir", ".")
-      FileUtils.mkdir_p(dir) unless File.exist?(dir)
+      FileUtils.mkdir_p(dir)
       File.join(dir, Zaru.sanitize!("#{Time.now.nsec}-#{opts['subject']}.html"))
     end
   end


### PR DESCRIPTION
As per the [ Ruby style guide](https://rubystyle.guide#atomic-file-operations), parallel file operations can be problematic. In this case, it's preferred to omit the existence check as it's unneeded.

This is underscored by the following warning when Rubocop is run on this repo:

```
lib/lazylead/postman.rb:136:30: W: [Correctable] Lint/NonAtomicFileOperation: Remove unnecessary existence check File.exist?. (https://rubystyle.guide#atomic-file-operations)
      FileUtils.mkdir_p(dir) unless File.exist?(dir)
```